### PR TITLE
update docs on creating .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ git clone git@github.com:LatridellActiveX/Medorium-Roster.git
 cd Medorium-Roster
 ```
 
+## Create .env file and generate a secret
+
+`NOTE: you don't have to generate a key in development`
+
+```bash
+# go into api directory
+cd api
+
+# copy .env.example -> .env
+  # on windows:
+copy .env.example .env
+  # on linux:
+cp .env.example .env
+```
+
 ### Installing dependencies
 
 ```bash

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,2 +1,1 @@
-# https://generate-random.org/encryption-key-generator?count=1&bytes=32&cipher=aes-256-cbc&string=&password=
-JWT_SECRET="GENERATE A RANDOM KEY IN .env USING THE LINK ABOVE!!!" 
+JWT_SECRET="Make sure to generate a secure key in production" 


### PR DESCRIPTION
Included example on how to copy .env.example file to .env on windows and linux.
Made it clear that JWT_SECRET key does not have to be generated in development.